### PR TITLE
Add media text block style variations

### DIFF
--- a/assets/variables.css
+++ b/assets/variables.css
@@ -12,4 +12,6 @@
 	--font-header: 'Poppins', sans-serif;
 	--font-body: 'Karla', sans-serif;
 	--font-compressed: 'Francois One', sans-serif;
+
+	--default-content-width: 600px;
 }

--- a/functions.php
+++ b/functions.php
@@ -91,6 +91,38 @@ function enqueue_styles() : void {
 }
 
 /**
+ * Register block style variations.
+ */
+if ( function_exists( 'register_block_style' ) ) {
+	register_block_style(
+		'core/media-text',
+		array(
+			'name'         => 'border-dark',
+			'label'        => 'Dark',
+			'style_handle' => 'theme-style',
+		)
+	);
+
+	register_block_style(
+		'core/media-text',
+		array(
+			'name'         => 'border-alt',
+			'label'        => 'Alt',
+			'style_handle' => 'theme-style',
+		)
+	);
+
+	register_block_style(
+		'core/media-text',
+		array(
+			'name'         => 'border-accent',
+			'label'        => 'Accent',
+			'style_handle' => 'theme-style',
+		)
+	);
+}
+
+/**
  * Add Google webfonts
  *
  * @return string

--- a/style-editor.css
+++ b/style-editor.css
@@ -96,3 +96,8 @@ figcaption,
 	color: var(--color-accent-text);
 	border: 10px solid var(--color-accent-border);
 }
+
+div[class*="is-style-border-"].wp-block-media-text {
+	margin: auto;
+	max-width: var(--default-content-width);
+}

--- a/style-editor.css
+++ b/style-editor.css
@@ -81,3 +81,18 @@ figcaption,
 	color: var( --color-dark-text );
 	font-family: var( --font-body );
 }
+
+.is-style-border-dark {
+	color: var(--color-dark-text);
+	border: 10px solid var(--color-dark-border);
+}
+
+.is-style-border-alt {
+	color: 10px solid var(--color-dark-alt-text);
+	border: 10px solid var(--color-dark-alt-border);
+}
+
+.is-style-border-accent {
+	color: var(--color-accent-text);
+	border: 10px solid var(--color-accent-border);
+}

--- a/style.css
+++ b/style.css
@@ -141,3 +141,18 @@ a {
 .wp-block-pullquote::before {
 	color: var( --color-accent-text );
 }
+
+.is-style-border-dark {
+	color: var(--color-dark-text);
+	border: 10px solid var(--color-dark-border);
+}
+
+.is-style-border-alt {
+	color: 10px solid var(--color-dark-alt-text);
+	border: 10px solid var(--color-dark-alt-border);
+}
+
+.is-style-border-accent {
+	color: var(--color-accent-text);
+	border: 10px solid var(--color-accent-border);
+}

--- a/style.css
+++ b/style.css
@@ -156,3 +156,12 @@ a {
 	color: var(--color-accent-text);
 	border: 10px solid var(--color-accent-border);
 }
+
+div[class*="is-style-border-"].wp-block-media-text {
+	margin: auto;
+	max-width: var(--default-content-width);
+}
+
+div[class*="is-style-border-"] > .wp-block-media-text__content {
+	padding: 2rem;
+}


### PR DESCRIPTION
This PR adds three block style variations to the core media & text block, addressing #1 and as an alternative to #12 .

**Editor (minor bug that seems like a Gutenberg issue not worth addressing)**
<img width="1172" alt="Screen Shot 2020-04-23 at 10 17 47 PM" src="https://user-images.githubusercontent.com/5375500/80168331-8fb58e00-85b0-11ea-8d7c-4c5eb05a856f.png">

**Front-end**
<img width="654" alt="Screen Shot 2020-04-23 at 10 17 35 PM" src="https://user-images.githubusercontent.com/5375500/80168336-947a4200-85b0-11ea-8160-45c1fb459202.png">
