### PR TITLE
Styles accordion block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ wordpress
 *.code-workspace
 twentytwenty
 /vendor/
+import.xml

--- a/style-editor.css
+++ b/style-editor.css
@@ -101,3 +101,33 @@ div[class*="is-style-border-"].wp-block-media-text {
 	margin: auto;
 	max-width: var(--default-content-width);
 }
+
+.wp-block-coblocks-accordion-item,
+.wp-block-coblocks-accordion-item__title,
+.wp-block-coblocks-accordion-item__content {
+	border-radius: 0;
+}
+.wp-block-coblocks-accordion-item__title {
+	font-family: var( --font-header );
+	font-weight: 700;
+}
+.wp-block-coblocks-accordion-item {
+	position: relative;
+}
+.wp-block-coblocks-accordion-item::after {
+	content: '\FF0B';
+	right: 10px;
+	font-size: 30px;
+	line-height: 51px;
+	opacity: 0.5;
+	font-family: monospace;
+	position: absolute;
+	top: 0;
+}
+.wp-block-coblocks-accordion-item--open::after {
+	content: '\FF0D';
+}
+.wp-block-coblocks-accordion-item__title.has-background {
+	padding-top: 10px;
+	padding-bottom: 10px;
+}

--- a/style-editor.css
+++ b/style-editor.css
@@ -107,10 +107,6 @@ div[class*="is-style-border-"].wp-block-media-text {
 .wp-block-coblocks-accordion-item__content {
 	border-radius: 0;
 }
-.wp-block-coblocks-accordion-item__title {
-	font-family: var( --font-header );
-	font-weight: 700;
-}
 .wp-block-coblocks-accordion-item {
 	position: relative;
 }
@@ -119,15 +115,22 @@ div[class*="is-style-border-"].wp-block-media-text {
 	right: 10px;
 	font-size: 30px;
 	line-height: 51px;
-	opacity: 0.5;
 	font-family: monospace;
 	position: absolute;
 	top: 0;
+	opacity: 0.5;
 }
 .wp-block-coblocks-accordion-item--open::after {
 	content: '\FF0D';
 }
+.wp-block-coblocks-accordion-item__title {
+	font-family: var( --font-header );
+	font-weight: 700;
+	color: var( --color-dark-alt-text );
+	background-color: rgba(215, 230, 231, 0.5);
+}
 .wp-block-coblocks-accordion-item__title.has-background {
 	padding-top: 10px;
 	padding-bottom: 10px;
+	color: #fff;
 }

--- a/style.css
+++ b/style.css
@@ -278,6 +278,8 @@ div[class*="is-style-border-"] > .wp-block-media-text__content {
 	font-family: var( --font-header );
 	font-weight: 700;
 	list-style: none;
+	color: var( --color-dark-alt-text );
+	background-color: rgba(215, 230, 231, 0.5);
 }
 .wp-block-coblocks-accordion-item__title::-webkit-details-marker {
 	display: none;
@@ -288,8 +290,14 @@ div[class*="is-style-border-"] > .wp-block-media-text__content {
 	left: auto;
 	font-size: 30px;
 	line-height: 51px;
-	opacity: 0.5;
 	font-family: monospace;
+	color: var( --color-light-background );
+}
+.wp-block-coblocks-accordion-item__title.has-background::after {
+	opacity: 0.5;
+}
+.wp-block-coblocks-accordion-item__title.has-text-color::after {
+	color: inherit;
 }
 .wp-block-coblocks-accordion-item > details[open] > .wp-block-coblocks-accordion-item__title::after {
 	content: '\FF0D';

--- a/style.css
+++ b/style.css
@@ -279,6 +279,7 @@ div[class*="is-style-border-"] > .wp-block-media-text__content {
 	font-weight: 700;
 	list-style: none;
 	color: var( --color-dark-alt-text );
+	cursor: pointer;
 	background-color: rgba(215, 230, 231, 0.5);
 }
 .wp-block-coblocks-accordion-item__title::-webkit-details-marker {

--- a/style.css
+++ b/style.css
@@ -68,6 +68,10 @@ a {
 	color: var( --color-accent-text );
 }
 
+.widget_text p, .widget_text ol, .widget_text ul, .widget_text dl, .widget_text dt, .widget-content .rssSummary {
+	font-family: var( --font-body );
+}
+
 /*--------------------------------------------------------------
 # Utilities
 --------------------------------------------------------------*/
@@ -86,6 +90,22 @@ a {
 }
 :root .has-dark-alt-color {
 	color: var( --color-dark-alt-text );
+}
+:root .has-dark-alt-background-color {
+	background-color: var( --color-dark-alt-text );
+}
+:root .has-accent-background-color {
+	color: var( --color-accent-background );
+	background-color: inherit;
+}
+:root .has-accent-background-background-color {
+	background-color: var( --color-accent-background );
+}
+:root .has-light-background-color {
+	color: var( --color-light-background );
+}
+:root .has-light-background-background-color {
+	background-color: var( --color-light-background );
 }
 
 /*--------------------------------------------------------------
@@ -160,6 +180,16 @@ a {
 # These provide front-end block styles.
 --------------------------------------------------------------*/
 
+button, .button, .faux-button, .wp-block-button__link, .wp-block-file .wp-block-file__button, input[type="button"], input[type="reset"], input[type="submit"] {
+	background: var( --color-primary-text );
+	font-family: var( --font-header );
+	border-radius: 1000px;
+}
+
+.wp-block-button.is-style-outline {
+	color: var( --color-primary-text );
+}
+
 .wp-block-button__link {
 	background-color: var( --color-primary-text );
 }
@@ -192,6 +222,22 @@ a {
 
 .wp-block-quote cite {
 	color: var( --color-dark-text );
+	font-family: var( --font-body );
+}
+
+.has-drop-cap:not(:focus)::first-letter,
+	.entry-content cite,
+	.entry-content figcaption,
+	.entry-content table,
+	.entry-content address,
+	.entry-content .wp-caption-text,
+	.entry-content .wp-block-file,
+	.entry-content .wp-block-archives,
+	.entry-content .wp-block-categories,
+	.entry-content .wp-block-latest-posts,
+	.entry-content .wp-block-latest-comments,
+	.entry-content .wp-block-cover-image p,
+	.entry-content .wp-block-pullquote {
 	font-family: var( --font-body );
 }
 

--- a/style.css
+++ b/style.css
@@ -268,3 +268,41 @@ div[class*="is-style-border-"].wp-block-media-text {
 div[class*="is-style-border-"] > .wp-block-media-text__content {
 	padding: 2rem;
 }
+
+.wp-block-coblocks-accordion-item,
+.wp-block-coblocks-accordion-item > details > summary.wp-block-coblocks-accordion-item__title,
+.wp-block-coblocks-accordion-item__content {
+	border-radius: 0;
+}
+.wp-block-coblocks-accordion-item__title {
+	font-family: var( --font-header );
+	font-weight: 700;
+	list-style: none;
+}
+.wp-block-coblocks-accordion-item__title::-webkit-details-marker {
+	display: none;
+}
+.wp-block-coblocks-accordion-item__title::after {
+	content: '\FF0B';
+	right: 10px;
+	left: auto;
+	font-size: 30px;
+	line-height: 51px;
+	opacity: 0.5;
+	font-family: monospace;
+}
+.wp-block-coblocks-accordion-item > details[open] > .wp-block-coblocks-accordion-item__title::after {
+	content: '\FF0D';
+}
+.wp-block-coblocks-accordion-item__title:not(.has-background) + .wp-block-coblocks-accordion-item__content {
+	border-color: transparent;
+}
+.wp-block-coblocks-accordion-item__title:not(.has-background).has-secondary-color {
+	background-color: var( --color-accent-border );
+}
+.wp-block-coblocks-accordion-item__title:not(.has-background).has-dark-color {
+	background-color: var( --color-dark-alt-border );
+}
+.wp-block-coblocks-accordion-item__title:not(.has-background).has-dark-alt-color {
+	background-color: var( --color-dark-alt-border );
+}

--- a/style.css
+++ b/style.css
@@ -301,7 +301,7 @@ div[class*="is-style-border-"] > .wp-block-media-text__content {
 	background-color: var( --color-accent-border );
 }
 .wp-block-coblocks-accordion-item__title:not(.has-background).has-dark-color {
-	background-color: var( --color-dark-alt-border );
+	background-color: var( --color-dark-border );
 }
 .wp-block-coblocks-accordion-item__title:not(.has-background).has-dark-alt-color {
 	background-color: var( --color-dark-alt-border );


### PR DESCRIPTION
Fixes #5, relied on #18.

**Notes**
* Decided if a background color is explicitly set, the border wraps the accordion content.
* If a background color is not set but a text color is, border colors are chosen for background but can be overridden. Automatic background color does not appear in editor, due to how the markup is structured.

**Screenshots**
<img width="706" alt="Screen Shot 2020-04-28 at 10 09 18 PM" src="https://user-images.githubusercontent.com/1760168/80555059-20b7ab00-899d-11ea-9611-21e4f98bbec2.png">
Editor view. First block has explicit background set, second does not.

<img width="623" alt="Screen Shot 2020-04-28 at 10 09 40 PM" src="https://user-images.githubusercontent.com/1760168/80555073-28774f80-899d-11ea-853c-c6377e7c6d72.png">
Front end. Note new color.