### PR TITLE
Fixes styles for HR tags

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -27,6 +27,10 @@ figcaption,
 	font-family: var( --font-header );
 }
 
+.editor-post-title__input {
+	text-align: center;
+}
+
 h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
 	text-decoration: none !important; /* Overrides :hover and :active states. */
 }
@@ -63,6 +67,10 @@ h4 > strong {
 
 .block-editor-rich-text__editable a {
 	color: var( --color-accent-text );
+}
+
+.wp-block-paragraph.has-background-color {
+	color: #ffffff;
 }
 
 .wp-block-button .wp-block-button__link {
@@ -144,4 +152,19 @@ div[class*="is-style-border-"].wp-block-media-text {
 	padding-top: 10px;
 	padding-bottom: 10px;
 	color: #fff;
+}
+
+.wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
+	max-width: none;
+	border-bottom-width: 1px;
+	border-bottom-color: #6d6d6d;
+}
+.wp-block-separator.is-style-wide {
+	margin-left: -10em;
+	margin-right: -10em;
+}
+.wp-block-separator.is-style-dots::before {
+	font-size: 3.2rem;
+	letter-spacing: 1em;
+	padding-left: 1em;
 }

--- a/style.css
+++ b/style.css
@@ -370,3 +370,13 @@ div[class*="is-style-border-"] > .wp-block-media-text__content {
 .wp-block-coblocks-accordion-item__title:not(.has-background).has-dark-alt-color {
 	background-color: var( --color-secondary-border );
 }
+
+.entry-content hr, hr.styled-separator {
+	background: currentColor !important; /* Overrides !important in parent styles. */
+}
+.entry-content hr:not(.is-style-dots)::before,
+hr.styled-separator:not(.is-style-dots)::before,
+.entry-content hr:not(.is-style-dots)::after,
+hr.styled-separator:not(.is-style-dots)::after {
+	display: none;
+}


### PR DESCRIPTION
Fixes #26.

Front end:
<img width="1281" alt="Screen Shot 2020-05-01 at 4 30 47 PM" src="https://user-images.githubusercontent.com/1760168/80839443-40331b80-8bc9-11ea-8dbc-7413ee253469.png">

Editor:
<img width="910" alt="Screen Shot 2020-05-01 at 4 30 59 PM" src="https://user-images.githubusercontent.com/1760168/80839445-40cbb200-8bc9-11ea-8b44-fbdeff141e82.png">
