### PR TITLE
Changes alt highlight to have border and background

### DIFF
--- a/assets/colors.css
+++ b/assets/colors.css
@@ -29,8 +29,8 @@
 	background-color: var( --color-highlight );
 }
 :root .has-highlight-alt-color {
-	color: var( --color-highlight-alt );
+	color: var( --color-highlight-alt-text );
 }
 :root .has-highlight-alt-background-color {
-	background-color: var( --color-highlight-alt );
+	background-color: var( --color-highlight-alt-border );
 }

--- a/assets/editor-tweaks.css
+++ b/assets/editor-tweaks.css
@@ -1,0 +1,9 @@
+.block-editor-color-gradient-control ~ .block-editor-color-gradient-control .component-color-indicator[aria-label='(Color: #a4cacb)'],
+.component-color-indicator[aria-label='(background color: color Alternative Highlight Background)'] {
+	background-color: var( --color-highlight-alt-border ) !important;
+}
+
+.block-editor-color-gradient-control ~ .block-editor-color-gradient-control button[aria-label='Color: Alternative Highlight Background'] {
+	color: var( --color-highlight-alt-border ) !important;
+	background-color: var( --color-highlight-alt-border ) !important;
+}

--- a/assets/variables.css
+++ b/assets/variables.css
@@ -7,7 +7,8 @@
 	--color-tertiary-text: #47133d;
 	--color-tertiary-border: #a17193;
 	--color-highlight: #f7cf56;
-	--color-highlight-alt: #a4cacb;
+	--color-highlight-alt-text: #a4cacb;
+	--color-highlight-alt-border: #ebf3f3;
 
 	--font-header: 'Poppins', sans-serif;
 	--font-body: 'Karla', sans-serif;

--- a/functions.php
+++ b/functions.php
@@ -21,6 +21,7 @@ function setup() : void {
 	remove_action( 'enqueue_block_editor_assets', 'twentytwenty_block_editor_styles', 1 );
 	remove_action( 'widgets_init', 'twentytwenty_sidebar_registration' );
 	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_styles', 10 );
+	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_editor_styles' );
 
 	add_filter( 'twentytwenty_get_elements_array', '__return_empty_array' );
 	add_filter( 'theme_mod_custom_logo', '__return_true' );
@@ -99,6 +100,10 @@ function setup() : void {
 			}
 		);
 	}
+
+	$theme_version = wp_get_theme()->get( 'Version' );
+	wp_register_style( 'theme-style-variables', get_stylesheet_directory_uri() . '/assets/variables.css', [], $theme_version );
+	wp_register_style( 'theme-style-colors', get_stylesheet_directory_uri() . '/assets/colors.css', [], $theme_version );
 }
 
 /**
@@ -117,11 +122,17 @@ function enqueue_styles() : void {
 	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_enqueue_style( 'theme-fonts', fonts_url(), [], null );
 
-	// Enqueue theme CSS variables.
-	wp_enqueue_style( 'theme-style-variables', get_stylesheet_directory_uri() . '/assets/variables.css', [], $theme_version );
-	wp_enqueue_style( 'theme-style-colors', get_stylesheet_directory_uri() . '/assets/colors.css', [], $theme_version );
-
 	wp_enqueue_style( 'theme-style', get_stylesheet_uri(), [ 'parent-style', 'theme-style-variables', 'theme-style-colors' ], $theme_version );
+}
+
+/**
+ * Enqueues styles for the block editor.
+ *
+ * @since 1.0.1
+ * @return void
+ */
+function enqueue_editor_styles() : void {
+	wp_enqueue_style( 'theme-editor-tweaks', get_stylesheet_directory_uri() . '/assets/editor-tweaks.css', [ 'theme-style-variables' ], wp_get_theme()->get( 'Version' ) );
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -488,7 +488,7 @@ div[class*='is-style-border-'] > .wp-block-media-text__content {
 	list-style: none;
 	color: var( --color-secondary-text );
 	cursor: pointer;
-	background-color: rgba( 215, 230, 231, 0.5 );
+	background-color: var( --color-highlight-alt-border );
 }
 .wp-block-coblocks-accordion-item__title::-webkit-details-marker {
 	display: none;
@@ -500,7 +500,7 @@ div[class*='is-style-border-'] > .wp-block-media-text__content {
 	font-size: 30px;
 	line-height: 51px;
 	font-family: monospace;
-	color: var( --color-highlight-alt );
+	color: var( --color-highlight-alt-text );
 }
 .wp-block-coblocks-accordion-item__title.has-background::after {
 	opacity: 0.5;
@@ -515,13 +515,13 @@ div[class*='is-style-border-'] > .wp-block-media-text__content {
 	border-color: transparent;
 }
 .wp-block-coblocks-accordion-item__title:not( .has-background ).has-secondary-color {
-	background-color: var( --color-accent-border );
+	background-color: var( --color-secondary-border );
 }
-.wp-block-coblocks-accordion-item__title:not( .has-background ).has-dark-color {
+.wp-block-coblocks-accordion-item__title:not( .has-background ).has-tertiary-color {
 	background-color: var( --color-tertiary-border );
 }
-.wp-block-coblocks-accordion-item__title:not( .has-background ).has-dark-alt-color {
-	background-color: var( --color-secondary-border );
+.wp-block-coblocks-accordion-item__title:not( .has-background ).has-accent-color {
+	background-color: var( --color-accent-border );
 }
 
 .entry-content hr, hr.styled-separator {


### PR DESCRIPTION
Fixes #43.

Makes it so there are a `highlight-alt` text and border color, one for text and one for lighter applications like backgrounds and borders.