### PR TITLE
Adds new emphasized paragraph style

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -132,7 +132,7 @@ if ( function_exists( 'register_block_style' ) ) {
 		'core/media-text',
 		array(
 			'name'         => 'border-alt',
-			'label'        => 'Secondary',
+			'label'        => __( 'Secondary', 'mutualaidnyc' ),
 			'style_handle' => 'theme-style',
 		)
 	);
@@ -141,7 +141,7 @@ if ( function_exists( 'register_block_style' ) ) {
 		'core/media-text',
 		array(
 			'name'         => 'border-dark',
-			'label'        => 'Tertiary',
+			'label'        => __( 'Tertiary', 'mutualaidnyc' ),
 			'style_handle' => 'theme-style',
 		)
 	);
@@ -150,7 +150,16 @@ if ( function_exists( 'register_block_style' ) ) {
 		'core/media-text',
 		array(
 			'name'         => 'border-accent',
-			'label'        => 'Accent',
+			'label'        => __( 'Accent', 'mutualaidnyc' ),
+			'style_handle' => 'theme-style',
+		)
+	);
+
+	register_block_style(
+		'core/paragraph',
+		array(
+			'name'         => 'emphasis',
+			'label'        => __( 'Emphasized', 'mutualaidnyc' ),
 			'style_handle' => 'theme-style',
 		)
 	);

--- a/style-editor.css
+++ b/style-editor.css
@@ -167,6 +167,8 @@ p:not( [class*='-font-size'] ) {
 .is-style-emphasis {
 	color: var( --color-accent-text );
 	font-family: var( --font-header );
+	font-weight: bold;
+	letter-spacing: -0.0415625em;
 }
 .is-style-emphasis:not( [class*='-font-size'] ) {
 	font-size: 1.95em;

--- a/style-editor.css
+++ b/style-editor.css
@@ -164,6 +164,14 @@ p:not( [class*='-font-size'] ) {
 	border: 10px solid var( --color-accent-border );
 }
 
+.is-style-emphasis {
+	color: var( --color-accent-text );
+	font-family: var( --font-header );
+}
+.is-style-emphasis:not( [class*='-font-size'] ) {
+	font-size: 1.95em;
+}
+
 div[class*='is-style-border-'].wp-block-media-text {
 	margin: auto;
 	max-width: var( --default-content-width );

--- a/style.css
+++ b/style.css
@@ -468,6 +468,21 @@ input[type='submit'] {
 	border: 10px solid var( --color-accent-border );
 }
 
+p.is-style-emphasis {
+	color: var( --color-accent-text );
+	font-family: var( --font-header );
+	font-weight: bold;
+	letter-spacing: -0.0415625em;
+}
+.is-style-emphasis:not( [class*='-font-size'] ) {
+	font-size: 3.2rem;
+}
+@media ( min-width: 700px ) {
+	.is-style-emphasis:not( [class*='-font-size'] ) {
+		font-size: 4.8rem;
+	}
+}
+
 div[class*='is-style-border-'].wp-block-media-text {
 	margin: auto;
 	max-width: var( --default-content-width );


### PR DESCRIPTION
Fixes #45.

This PR adds an alternative paragraph style to add emphasis. This functions via adding a new class to the `p` tag, and should not impact accessibility.

One sentence is a paragraph, one is an h2:
<img width="713" alt="Screen Shot 2020-05-13 at 11 34 43 PM" src="https://user-images.githubusercontent.com/1760168/81889751-5bf7d380-9572-11ea-885e-fad240685292.png">