### PR TITLE
Reorders heading styles

### DIFF
--- a/assets/variables.css
+++ b/assets/variables.css
@@ -11,7 +11,6 @@
 
 	--font-header: 'Poppins', sans-serif;
 	--font-body: 'Karla', sans-serif;
-	--font-compressed: 'Francois One', sans-serif;
 
 	--default-content-width: 70rem;
 }

--- a/functions.php
+++ b/functions.php
@@ -183,7 +183,6 @@ function fonts_url() : string {
 
 	$font_families   = array();
 	$font_families[] = 'family=Poppins:wght@700;900';
-	$font_families[] = 'family=Francois+One';
 	$font_families[] = 'family=Karla:ital,wght@0,400;0,700;1,400;1,700';
 	$font_families[] = 'display=swap';
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -32,6 +32,7 @@ dt {
 .editor-post-title__input,
 h1,
 h2,
+h3,
 h4,
 h5,
 h6,
@@ -58,26 +59,25 @@ h1 {
 }
 
 h2 {
-	color: var( --color-accent-text );
-}
-
-h3 {
-	font-family: var( --font-compressed );
-	font-size: 1em;
-	color: var( --color-secondary-text );
-}
-
-h4 {
 	color: var( --color-tertiary-text );
-	font-size: 1.75em;
+	font-size: 1.2em;
 	line-height: 1.4;
 }
 
-h4 > strong {
+h2 > strong {
 	background-color: var( --color-highlight );
 	padding: 0 0.3em;
 	-webkit-box-decoration-break: clone;
 	box-decoration-break: clone;
+}
+
+h3 {
+	font-size: 0.9em;
+}
+
+h4, h5, h6 {
+	font-size: 0.6em;
+	text-transform: inherit;
 }
 
 .has-small-font-size {

--- a/style-editor.css
+++ b/style-editor.css
@@ -59,13 +59,14 @@ h1 {
 }
 
 h2 {
-	color: var( --color-tertiary-text );
+	color: var( --color-secondary-text );
 	font-size: 1.2em;
 	line-height: 1.4;
 }
 
 h2 > strong {
 	background-color: var( --color-highlight );
+	color: var( --color-tertiary-text );
 	padding: 0 0.3em;
 	-webkit-box-decoration-break: clone;
 	box-decoration-break: clone;
@@ -73,6 +74,7 @@ h2 > strong {
 
 h3 {
 	font-size: 0.9em;
+	color: var( --color-tertiary-text );
 }
 
 h4, h5, h6 {

--- a/style.css
+++ b/style.css
@@ -55,13 +55,14 @@ h1 {
 }
 
 h2 {
-	color: var( --color-tertiary-text );
+	color: var( --color-secondary-text );
 	font-size: 1.2em;
 	line-height: 1.4;
 }
 
 h2 > strong {
 	background-color: var( --color-highlight );
+	color: var( --color-tertiary-text );
 	padding: 0 0.3em;
 	-webkit-box-decoration-break: clone;
 	box-decoration-break: clone;
@@ -69,6 +70,7 @@ h2 > strong {
 
 h3 {
 	font-size: 0.9em;
+	color: var( --color-tertiary-text );
 }
 
 h4, h5, h6 {

--- a/style.css
+++ b/style.css
@@ -32,14 +32,11 @@ body,
 
 .entry-content h1,
 .entry-content h2,
+.entry-content h3,
 .entry-content h4,
 .entry-content h5,
 .entry-content h6 {
 	font-family: var( --font-header );
-}
-
-.entry-content h3 {
-	font-family: var( --font-compressed );
 }
 
 h1, h2, h4, h5, h6 {
@@ -58,26 +55,25 @@ h1 {
 }
 
 h2 {
-	color: var( --color-accent-text );
-}
-
-h3 {
-	font-family: var( --font-compressed );
-	font-size: 1em;
-	color: var( --color-secondary-text );
-}
-
-h4 {
-	color: var( --color-dark-text );
-	font-size: 1.75em;
+	color: var( --color-tertiary-text );
+	font-size: 1.2em;
 	line-height: 1.4;
 }
 
-h4 > strong {
+h2 > strong {
 	background-color: var( --color-highlight );
 	padding: 0 0.3em;
 	-webkit-box-decoration-break: clone;
 	box-decoration-break: clone;
+}
+
+h3 {
+	font-size: 0.9em;
+}
+
+h4, h5, h6 {
+	font-size: 0.6em;
+	text-transform: inherit;
 }
 
 a {


### PR DESCRIPTION
Fixes #48.

This PR does the following:
* Changes the order of header tag styles as per the issue.
* Removes unused font.

Front end:
<img width="591" alt="Screen Shot 2020-05-15 at 10 09 02 PM" src="https://user-images.githubusercontent.com/1760168/82107899-0c8fdf80-96f9-11ea-86bb-b3b6e8e79875.png">

Back end:
<img width="591" alt="Screen Shot 2020-05-15 at 10 09 02 PM" src="https://user-images.githubusercontent.com/1760168/82107902-10bbfd00-96f9-11ea-9d0d-fe3038726603.png">
