### PR TITLE
Resizes headers to be more mobile-friendly

### DIFF
--- a/style.css
+++ b/style.css
@@ -171,8 +171,7 @@ body {
 
 .cover-header .cover-header-inner-wrapper {
 	justify-content: center;
-	min-height: auto;
-	height: 320px;
+	min-height: 320px;
 	max-height: 100vh;
 }
 
@@ -192,7 +191,7 @@ body {
 }
 
 .cover-header-inner {
-	padding: 0;
+	padding: 15rem 0;
 }
 
 .cover-header .entry-header .entry-title {


### PR DESCRIPTION
Fixes #52.

This changes the sizing of the headers to scale up as more text is added instead of having a static height.

### Screenshots
<img width="379" alt="Screen Shot 2020-05-15 at 10 27 35 PM" src="https://user-images.githubusercontent.com/1760168/82108307-a6588c00-96fb-11ea-8bf1-f7c578baefbb.png">
<img width="773" alt="Screen Shot 2020-05-15 at 10 27 42 PM" src="https://user-images.githubusercontent.com/1760168/82108311-a6f12280-96fb-11ea-9a15-485d3d51091b.png">
<img width="1678" alt="Screen Shot 2020-05-15 at 10 27 56 PM" src="https://user-images.githubusercontent.com/1760168/82108313-a789b900-96fb-11ea-827f-a549ef0de56a.png">
