### PR TITLE
Removes Jetpack from TranslatePress

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -38,6 +38,8 @@ function setup() : void {
 	add_action( 'customize_controls_enqueue_scripts', __NAMESPACE__ . '\\remove_customizer_scripts', 11 );
 	add_action( 'customize_register', __NAMESPACE__ . '\\register_customizer', 11 );
 
+	add_filter( 'trp_skip_gettext_processing', __NAMESPACE__ . '\\skip_jetpack_translation', 10, 4 );
+
 	global $content_width;
 	$content_width = 700;
 
@@ -255,5 +257,21 @@ function register_customizer( WP_Customize_Manager $wp_customize ) : void {
 	];
 	foreach ( $controls as $control ) {
 		$wp_customize->remove_control( $control );
+	}
+
+	/**
+	 * Removes Jetpack from TranslatePress translation options.
+	 *
+	 * @param bool   $return
+	 * @param string $translation
+	 * @param string $text
+	 * @param string $domain
+	 * @return bool
+	 */
+	function skip_jetpack_translation( $return, $translation, $text, string $domain ) {
+		if ( 'jetpack' === $domain ) {
+			return true;
+		}
+		return $return;
 	}
 }

--- a/functions.php
+++ b/functions.php
@@ -258,20 +258,20 @@ function register_customizer( WP_Customize_Manager $wp_customize ) : void {
 	foreach ( $controls as $control ) {
 		$wp_customize->remove_control( $control );
 	}
+}
 
-	/**
-	 * Removes Jetpack from TranslatePress translation options.
-	 *
-	 * @param bool   $return      What the filter is returning.
-	 * @param string $translation Unused.
-	 * @param string $text        Unused.
-	 * @param string $domain      The domain of the gettext.
-	 * @return bool
-	 */
-	function skip_jetpack_translation( bool $return, $translation, $text, string $domain ) : bool {
-		if ( 'jetpack' === $domain ) {
-			return true;
-		}
-		return $return;
+/**
+ * Removes Jetpack from TranslatePress translation options.
+ *
+ * @param bool   $return      What the filter is returning.
+ * @param string $translation Unused.
+ * @param string $text        Unused.
+ * @param string $domain      The domain of the gettext.
+ * @return mixed
+ */
+function skip_jetpack_translation( $return, $translation, $text, string $domain ) {
+	if ( 'jetpack' === $domain ) {
+		return true;
 	}
+	return $return;
 }

--- a/functions.php
+++ b/functions.php
@@ -262,13 +262,13 @@ function register_customizer( WP_Customize_Manager $wp_customize ) : void {
 	/**
 	 * Removes Jetpack from TranslatePress translation options.
 	 *
-	 * @param bool   $return
-	 * @param string $translation
-	 * @param string $text
-	 * @param string $domain
+	 * @param bool   $return      What the filter is returning.
+	 * @param string $translation Unused.
+	 * @param string $text        Unused.
+	 * @param string $domain      The domain of the gettext.
 	 * @return bool
 	 */
-	function skip_jetpack_translation( $return, $translation, $text, string $domain ) {
+	function skip_jetpack_translation( bool $return, $translation, $text, string $domain ) : bool {
 		if ( 'jetpack' === $domain ) {
 			return true;
 		}


### PR DESCRIPTION
This code filters out any text with the domain Jetpack from translation logic.

The filter is based on logic found in [the TranslatePress plugin](https://bitbucket.org/cozmoslabs/translatepress/src/5ccf802217227fbd64e7946ebfbe97a7c1b13baa/includes/advanced-settings/exclude-gettext-strings.php).