### PR TITLE
Styles Resources Block

### DIFF
--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -27,15 +27,21 @@ function block_init() {
 		return;
 	}
 	$script_asset = require MANY_ASSETS_PATH . '/blocks/index.asset.php';
-	$index_js     = MANY_ASSETS_URL . '/blocks/index.js';
 	$block_paths  = MANY_ROOT_PATH . '/blocks';
 
 	wp_register_script(
 		'theme-blocks-editor',
-		$index_js,
+		MANY_ASSETS_URL . '/blocks/index.js',
 		$script_asset['dependencies'],
 		$script_asset['version'],
 		true
+	);
+	wp_register_style(
+		'theme-blocks-styles',
+		// Should be set to common URL once fixed: https://github.com/WordPress/gutenberg/issues/22776.
+		MANY_ROOT_URL . '/blocks/resources/style.css',
+		[],
+		$script_asset['version']
 	);
 
 	foreach ( BLOCKS as $block ) {

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -53,23 +53,32 @@ function render_callback( array $attributes ) : string {
 	$needs->populateRelatedField( 'Resources', $resources_query );
 
 	$html = sprintf(
-		'<div class="%s">',
+		'<div class="wp-block-resources %s">',
 		esc_attr( $attributes['className'] ?? '' )
 	);
 
-	$html .= '<ul>';
 	foreach ( $needs as $need ) {
-		$html .= sprintf( '<li>%s <ul>', esc_html( $need['Need'] ) );
+		$html .= '<details class="resources__need">';
+		$html .= sprintf( '<summary class="resources__need-title">%s</summary>', esc_html( $need['Need'] ) );
+		$html .= '<div class="resources__item-wrapper">';
 		foreach ( $need['Resources'] as $resource ) {
 			$html .= sprintf(
-				'<li><a href="%2$s">%1$s</a></li>',
+				'<div class="resources__item">
+					<span class="resources__tag resources__tag--%5$s">%4$s</span>
+					<p class="resources__item-title">%1$s</p>
+					%2$s
+					<p><a href="%3$s" class="resources__item-link">%3$s</a></p>
+				</div>',
 				esc_html( $resource['Resource Title'] ),
+				wp_kses_post( wpautop( wptexturize( $resource['Resource Details'] ) ) ),
 				esc_url( $resource['Link to Resource'] ?? '' ),
+				esc_html( $resource['Resource Type'] ),
+				esc_attr( strtolower( $resource['Resource Type'] ) )
 			);
 		}
-		$html .= '</ul></li>';
+		$html .= '</div>';
+		$html .= '</details>';
 	}
-	$html .= '</ul>';
 	$html .= '</div>';
 
 	return $html;

--- a/blocks/resources/index.js
+++ b/blocks/resources/index.js
@@ -1,6 +1,9 @@
 import { registerBlockType } from '@wordpress/blocks';
 import ServerSideRender from '@wordpress/server-side-render';
 
+// Commented out due to bug: https://github.com/WordPress/gutenberg/issues/22776
+// import './style.css';
+
 const ResourcesEdit = ( { attributes: { className } } ) => {
 	return (
 		<div className={ className }>

--- a/blocks/resources/style.css
+++ b/blocks/resources/style.css
@@ -1,0 +1,60 @@
+.resources__need {
+	margin-bottom: 1em;
+}
+.resources__need-title {
+	padding: 10px 15px;
+	position: relative;
+	font-family: var( --font-header );
+	font-weight: 700;
+	list-style: none;
+	color: var( --color-secondary-text );
+	cursor: pointer;
+	background-color: var( --color-highlight-alt-border );
+}
+.resources__need-title::-webkit-details-marker {
+	display: none;
+}
+.resources__need-title::after {
+	content: '\25BC';
+	right: 10px;
+	left: auto;
+	font-size: 30px;
+	font-family: monospace;
+	color: var( --color-secondary-text );
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	line-height: 1;
+	height: 30px;
+	margin: auto 0;
+}
+.resources__item {
+	margin: 4rem 10px;
+}
+.resources__tag {
+	display: inline-block;
+	font-family: var( --font-header );
+	font-size: 0.8em;
+	color: #fff;
+	padding: 0.5rem 1rem;
+	background-color: var( --color-primary-text );
+	text-transform: uppercase;
+}
+.resources__tag--service {
+	background-color: var( --color-tertiary-text );
+}
+.resources__tag--info {
+	background-color: var( --color-highlight );
+}
+.resources__tag--fund {
+	background-color: var( --color-secondary-text );
+}
+.resources__tag--course {
+	background-color: var( --color-accent-text );
+}
+p.resources__item-title {
+	font-size: 1.2em;
+	font-family: var( --font-header );
+	font-weight: bold;
+	margin: 1rem 0;
+}

--- a/blocks/resources/style.css
+++ b/blocks/resources/style.css
@@ -28,6 +28,9 @@
 	height: 30px;
 	margin: auto 0;
 }
+.resources__need[open] > summary::after {
+	content: '\25B2';
+}
 .resources__item {
 	margin: 4rem 10px;
 }

--- a/blocks/resources/style.css
+++ b/blocks/resources/style.css
@@ -45,6 +45,7 @@
 }
 .resources__tag--info {
 	background-color: var( --color-highlight );
+	color: var( --color-primary-text );
 }
 .resources__tag--fund {
 	background-color: var( --color-secondary-text );

--- a/functions.php
+++ b/functions.php
@@ -123,8 +123,6 @@ function enqueue_block_styles() : void {
 	$theme_version = wp_get_theme()->get( 'Version' );
 	wp_register_style( 'theme-style-variables', get_stylesheet_directory_uri() . '/assets/variables.css', [], $theme_version );
 	wp_register_style( 'theme-style-colors', get_stylesheet_directory_uri() . '/assets/colors.css', [], $theme_version );
-
-	wp_enqueue_script( 'theme-blocks-editor' );
 }
 
 /**
@@ -143,7 +141,12 @@ function enqueue_styles() : void {
 	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_enqueue_style( 'theme-fonts', fonts_url(), [], null );
 
-	wp_enqueue_style( 'theme-style', get_stylesheet_uri(), [ 'parent-style', 'theme-style-variables', 'theme-style-colors' ], $theme_version );
+	wp_enqueue_style(
+		'theme-style',
+		MANY_ROOT_URL . '/style.css',
+		[ 'parent-style', 'theme-style-variables', 'theme-style-colors', 'theme-blocks-styles' ],
+		$theme_version
+	);
 }
 
 /**
@@ -153,7 +156,13 @@ function enqueue_styles() : void {
  * @return void
  */
 function enqueue_editor_styles() : void {
-	wp_enqueue_style( 'theme-editor-tweaks', get_stylesheet_directory_uri() . '/assets/editor-tweaks.css', [ 'theme-style-variables' ], wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style(
+		'theme-editor-tweaks',
+		MANY_ASSETS_URL . '/editor-tweaks.css',
+		[ 'theme-style-variables', 'theme-blocks-styles' ],
+		wp_get_theme()->get( 'Version' )
+	);
+	wp_enqueue_script( 'theme-blocks-editor' );
 }
 
 /**

--- a/style-editor.css
+++ b/style-editor.css
@@ -194,17 +194,13 @@ div[class*='is-style-border-'].wp-block-media-text .wp-block-media-text__media >
 	position: relative;
 }
 .wp-block-coblocks-accordion-item::after {
-	content: '\FF0B';
+	content: '\25BC';
 	right: 10px;
 	font-size: 30px;
 	line-height: 51px;
 	font-family: monospace;
 	position: absolute;
 	top: 0;
-	opacity: 0.5;
-}
-.wp-block-coblocks-accordion-item--open::after {
-	content: '\FF0D';
 }
 .wp-block-coblocks-accordion-item__title {
 	font-family: var( --font-header );

--- a/style.css
+++ b/style.css
@@ -501,13 +501,13 @@ div[class*='is-style-border-'] > .wp-block-media-text__content {
 	display: none;
 }
 .wp-block-coblocks-accordion-item__title::after {
-	content: '\FF0B';
+	content: '\25BC';
 	right: 10px;
 	left: auto;
 	font-size: 30px;
 	line-height: 51px;
 	font-family: monospace;
-	color: var( --color-highlight-alt-text );
+	color: var( --color-secondary-text );
 }
 .wp-block-coblocks-accordion-item__title.has-background::after {
 	opacity: 0.5;

--- a/style.css
+++ b/style.css
@@ -516,7 +516,7 @@ div[class*='is-style-border-'] > .wp-block-media-text__content {
 	color: inherit;
 }
 .wp-block-coblocks-accordion-item > details[open] > .wp-block-coblocks-accordion-item__title::after {
-	content: '\FF0D';
+	content: '\25B2';
 }
 .wp-block-coblocks-accordion-item__title:not( .has-background ) + .wp-block-coblocks-accordion-item__content {
 	border-color: transparent;


### PR DESCRIPTION
Fixes #55.

This replicates the Accordion block markup and styles with data pulled in via AirPress.

<img width="738" alt="Screen Shot 2020-06-01 at 11 34 49 PM" src="https://user-images.githubusercontent.com/1760168/83479252-0bcfab00-a466-11ea-971c-834157a71c32.png">
