### PR TITLE
Add ids to summary blocks to allow for internal linking

### DIFF
--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -59,7 +59,11 @@ function render_callback( array $attributes ) : string {
 
 	foreach ( $needs as $need ) {
 		$html .= '<details class="resources__need">';
-		$html .= sprintf( '<summary class="resources__need-title">%s</summary>', esc_html( $need['Need'] ) );
+		$html .= sprintf( '<summary class="resources__need-title" id="%s">
+				%s
+			</summary>', 
+			urlencode( strtolower($need['Need']) ),	
+			$need['Need']);
 		$html .= '<div class="resources__item-wrapper">';
 		foreach ( $need['Resources'] as $resource ) {
 			$html .= sprintf(

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -58,13 +58,15 @@ function render_callback( array $attributes ) : string {
 	);
 
 	foreach ( $needs as $need ) {
-		$html .= '<details class="resources__need">';
-		$html .= sprintf( '<summary class="resources__need-title" id="%s">
-				%s
-			</summary>', 
-			urlencode( strtolower($need['Need']) ),	
-			$need['Need']);
-		$html .= '<div class="resources__item-wrapper">';
+		$anchor = preg_replace( '/[^a-z0-9]+/', '+', strtolower( $need['Need'] ) );
+		$anchor = trim( $anchor, '+' );
+		$html  .= '<details class="resources__need">';
+		$html  .= sprintf(
+			'<summary class="resources__need-title" id="%1$s">%2$s</summary>',
+			esc_attr( $anchor ),
+			esc_html( $need['Need'] )
+		);
+		$html  .= '<div class="resources__item-wrapper">';
 		foreach ( $need['Resources'] as $resource ) {
 			$html .= sprintf(
 				'<div class="resources__item">


### PR DESCRIPTION
Adding an id attribute to the `summary` blocks so that we can use `#` to link inside the page.

I'm lowercasing and url encoding, so special charaters are % encoded and spaces are plus signs. I don't love the plus signs. We could replace spaces with dashes instead if we want to make it slightly more aesthetically pleasing (but maybe it only bothers me 😆 🤷‍♂️) .

Worth noting that the last resource need has a description in parentheses. Leads to a weird # value. We could do the magic we're doing everything before parentheses if we want to avoid that?

Most resources are easy to figure out, but ones like the last one can be found by grabbing the id from the summary element, which we can show people how to do.

| Display  | Link |
| ------------- | ------------- |
| Additional Resource Libraries  | #additional+resource+libraries  |
| Childcare | #childcare  |
| Delivery/Transport | #delivery%2Ftransport |
| Social Service Guidance (e.g. support filing for unemployment) | #social+service+guidance+%28e.g.+support+filing+for+unemployment%29 |