### PR TITLE
Use h3 tags for resource titles

### DIFF
--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -81,7 +81,7 @@ function render_callback( array $attributes ) : string {
 			$html .= sprintf(
 				'<div class="resources__item">
 					<span class="resources__tag resources__tag--%5$s">%4$s</span>
-					<p class="resources__item-title">%1$s</p>
+					<h3 class="resources__item-title">%1$s</h3>
 					%2$s
 					<p><a href="%3$s" class="resources__item-link">%3$s</a></p>
 				</div>',

--- a/blocks/resources/style.css
+++ b/blocks/resources/style.css
@@ -63,9 +63,12 @@
 .resources__tag--course {
 	background-color: var( --color-accent-text );
 }
-p.resources__item-title {
+.entry-content h3.resources__item-title {
 	font-size: 1.2em;
-	font-family: var( --font-header );
+	font-family: var( --font-body );
+	color: black;
+	line-height: 1.476;
 	font-weight: bold;
+	letter-spacing: normal;
 	margin: 1rem 0;
 }


### PR DESCRIPTION
Switching the `<p>` tags for the resource headers to `<h3>` tags. This should help with accessibility. Screenreader users often navigate using headers. Still room for improvement, but I thought this would be a nice small change to increase usability.

I styled the headers to look just like they were when they were `<p>` tags so no one should notice the change visually.

Maybe another improvement could be using `<li>` elements for the `resources__item` blocks? 🤔 