### PR TITLE
Removes hack for bug with Gutenberg scripts

### DIFF
--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -38,8 +38,7 @@ function block_init() {
 	);
 	wp_register_style(
 		'theme-blocks-styles',
-		// Should be set to common URL once fixed: https://github.com/WordPress/gutenberg/issues/22776.
-		MANY_ROOT_URL . '/blocks/resources/style.css',
+		MANY_ASSETS_URL . '/blocks/style-index.css',
 		[],
 		$script_asset['version']
 	);

--- a/blocks/resources/index.js
+++ b/blocks/resources/index.js
@@ -1,8 +1,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import ServerSideRender from '@wordpress/server-side-render';
 
-// Commented out due to bug: https://github.com/WordPress/gutenberg/issues/22776
-// import './style.css';
+import './style.css';
 
 const ResourcesEdit = ( { attributes: { className } } ) => {
 	return (


### PR DESCRIPTION
This removes a hack for Gutenberg, which was resolved in the latest release.