### PR TITLE
Adds block stylesheet and creates group variant

### DIFF
--- a/assets/blocks.css
+++ b/assets/blocks.css
@@ -1,0 +1,25 @@
+/**
+ * Style Variants
+ */
+
+/* Group block outline style */
+.wp-block-group.is-style-outline.has-background {
+	background-color: unset;
+	color: inherit;
+	border: var( --border-width ) solid var( --color-primary-text );
+}
+.wp-block-group.is-style-outline.has-accent-background-color {
+	border-color: var( --color-accent-text );
+}
+.wp-block-group.is-style-outline.has-secondary-background-color {
+	border-color: var( --color-secondary-text );
+}
+.wp-block-group.is-style-outline.has-tertiary-background-color {
+	border-color: var( --color-tertiary-text );
+}
+.wp-block-group.is-style-outline.has-highlight-background-color {
+	border-color: var( --color-highlight );
+}
+.wp-block-group.is-style-outline.has-highlight-alt-background-color {
+	border-color: var( --color-highlight-alt-border );
+}

--- a/assets/variables.css
+++ b/assets/variables.css
@@ -14,4 +14,5 @@
 	--font-body: 'Karla', sans-serif;
 
 	--default-content-width: 70rem;
+	--border-width: 4px;
 }

--- a/functions.php
+++ b/functions.php
@@ -88,6 +88,8 @@ function setup() : void {
 			fonts_url(),
 			'assets/variables.css',
 			'assets/colors.css',
+			'assets/blocks.css',
+			'assets/blocks/style-index.css',
 			'style-editor.css',
 		)
 	);
@@ -136,8 +138,24 @@ function setup() : void {
  */
 function enqueue_block_styles() : void {
 	$theme_version = wp_get_theme()->get( 'Version' );
-	wp_register_style( 'theme-style-variables', get_stylesheet_directory_uri() . '/assets/variables.css', [], $theme_version );
-	wp_register_style( 'theme-style-colors', get_stylesheet_directory_uri() . '/assets/colors.css', [], $theme_version );
+	wp_register_style(
+		'theme-style-variables',
+		MANY_ASSETS_URL . '/variables.css',
+		[],
+		$theme_version
+	);
+	wp_register_style(
+		'theme-style-colors',
+		MANY_ASSETS_URL . '/colors.css',
+		[],
+		$theme_version
+	);
+	wp_register_style(
+		'theme-style-blocks',
+		MANY_ASSETS_URL . '/blocks.css',
+		[ 'theme-style-variables', 'theme-style-colors' ],
+		$theme_version
+	);
 }
 
 /**
@@ -159,7 +177,14 @@ function enqueue_styles() : void {
 	wp_enqueue_style(
 		'theme-style',
 		MANY_ROOT_URL . '/style.css',
-		[ 'parent-style', 'theme-style-variables', 'theme-style-colors', 'theme-blocks-styles', 'dashicons' ],
+		[
+			'parent-style',
+			'theme-style-variables',
+			'theme-style-colors',
+			'theme-style-blocks',
+			'theme-blocks-styles',
+			'dashicons',
+		],
 		$theme_version
 	);
 }
@@ -174,7 +199,7 @@ function enqueue_editor_styles() : void {
 	wp_enqueue_style(
 		'theme-editor-tweaks',
 		MANY_ASSETS_URL . '/editor-tweaks.css',
-		[ 'theme-style-variables', 'theme-blocks-styles' ],
+		[ 'theme-style-variables' ],
 		wp_get_theme()->get( 'Version' )
 	);
 	wp_enqueue_script( 'theme-blocks-editor' );
@@ -218,6 +243,15 @@ if ( function_exists( 'register_block_style' ) ) {
 			'label'        => __( 'Emphasized', 'mutualaidnyc' ),
 			'style_handle' => 'theme-style',
 		)
+	);
+
+	register_block_style(
+		'core/group',
+		[
+			'name'         => 'outline',
+			'label'        => __( 'Outline', 'mutualaidnyc' ),
+			'style_handle' => 'theme-style',
+		]
 	);
 }
 


### PR DESCRIPTION
Creates a style variant for the Group block that allows an outline color set instead of a background color:

<img width="740" alt="Screen Shot 2020-07-06 at 5 23 19 PM" src="https://user-images.githubusercontent.com/1760168/86646787-87fd6700-bfad-11ea-8b27-4050293a29cc.png">

Fixes #77.