### PR TITLE
Translate resources block

### DIFF
--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -56,7 +56,7 @@ function render_callback( array $attributes ) : string {
 		$url_converter = $trp->get_component( 'url_converter' );
 		$language_code = $url_converter->get_lang_from_url_string();
 	}
-	if ( $language_code ) {
+	if ( isset( $language_code ) ) {
 		$language_handler = $trp->get_component( 'languages' );
 		$language_name    = $language_handler->get_language_names( array( $language_code ), 'english_name' )[ $language_code ];
 

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -51,13 +51,13 @@ function render_callback( array $attributes ) : string {
 	$resources_query = new AirpressQuery( 'Resources', 0 );
 	$resources_query->addFilter( '{Publish Status of Resource} = "Published"' );
 
-	$trp = TRP_Translate_Press::get_trp_instance();
+	$trp           = TRP_Translate_Press::get_trp_instance();
 	$url_converter = $trp->get_component( 'url_converter' );
 	$language_code = $url_converter->get_lang_from_url_string();
 
 	if ( $language_code ) {
 		$language_handler = $trp->get_component( 'languages' );
-		$language_name = $language_handler->get_language_names( array( $language_code ), 'english_name' )[ $language_code ];
+		$language_name    = $language_handler->get_language_names( array( $language_code ), 'english_name' )[ $language_code ];
 		$resources_query->view( 'Published (' . $language_name . ') Resources grouped by Resource Type - site embed view' );
 	} else {
 		$resources_query->sort( 'Display First', 'desc' );

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -55,9 +55,9 @@ function render_callback( array $attributes ) : string {
 	$url_converter = $trp->get_component( 'url_converter' );
 	$language_code = $url_converter->get_lang_from_url_string();
 
-	if ($language_code) {
+	if ( $language_code ) {
 		$language_handler = $trp->get_component( 'languages' );
-		$language_name = $language_handler->get_language_names( array( $language_code ), 'english_name' )[$language_code];
+		$language_name = $language_handler->get_language_names( array( $language_code ), 'english_name' )[ $language_code ];
 		$resources_query->view( 'Published (' . $language_name . ') Resources grouped by Resource Type - site embed view' );
 	} else {
 		$resources_query->sort( 'Display First', 'desc' );
@@ -80,10 +80,10 @@ function render_callback( array $attributes ) : string {
 		if ( count( $need['Resources'] ) === 0 ) {
 			continue;
 		}
-		if ($language_code) {
+		if ( $language_code ) {
 			$need_name = $need[ $language_name . ' Translation' ];
 		} else {
-			$need_name = $need[ 'Need' ];
+			$need_name = $need['Need'];
 		}
 		$anchor = preg_replace( '/[^a-z0-9]+/', '+', strtolower( $need_name ) );
 		$anchor = trim( $anchor, '+' );

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -56,9 +56,9 @@ function render_callback( array $attributes ) : string {
 	$language_code = $url_converter->get_lang_from_url_string();
 
 	if ($language_code) {
-		$language_handler = $trp->get_component('languages');
-		$language_name = $language_handler->get_language_names(array($language_code), 'english_name')[$language_code];
-		$resources_query->view("Published (".$language_name.") Resources grouped by Resource Type - site embed view");
+		$language_handler = $trp->get_component( 'languages' );
+		$language_name = $language_handler->get_language_names( array( $language_code ), 'english_name' )[$language_code];
+		$resources_query->view( 'Published (' . $language_name . ') Resources grouped by Resource Type - site embed view' );
 	} else {
 		$resources_query->sort( 'Display First', 'desc' );
 	}
@@ -81,11 +81,11 @@ function render_callback( array $attributes ) : string {
 			continue;
 		}
 		if ($language_code) {
-			$need_name = $need[$language_name.' Translation'];
+			$need_name = $need[ $language_name . ' Translation' ];
 		} else {
-			$need_name = $need['Need'];
+			$need_name = $need[ 'Need' ];
 		}
-		$anchor = preg_replace( '/[^a-z0-9]+/', '+', strtolower($need_name));
+		$anchor = preg_replace( '/[^a-z0-9]+/', '+', strtolower( $need_name ) );
 		$anchor = trim( $anchor, '+' );
 		$html  .= '<details class="resources__need">';
 		$html  .= sprintf(

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -62,11 +62,11 @@ function render_callback( array $attributes ) : string {
 
 		$sort = array(
 			array(
-				'field' => $language_name . ' Display Ranking',
+				'field'     => $language_name . ' Display Ranking',
 				'direction' => 'desc',
 			),
 			array(
-				'field' => 'Display First',
+				'field'     => 'Display First',
 				'direction' => 'desc',
 			),
 		);

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -51,7 +51,7 @@ function render_callback( array $attributes ) : string {
 	$resources_query = new AirpressQuery( 'Resources', 0 );
 	$resources_query->addFilter( '{Publish Status of Resource} = "Published"' );
 
-	if (class_exists('TRP_TRANSLATE_PRESS')) {
+	if ( class_exists( 'TRP_TRANSLATE_PRESS' ) ) {
 		$trp           = TRP_Translate_Press::get_trp_instance();
 		$url_converter = $trp->get_component( 'url_converter' );
 		$language_code = $url_converter->get_lang_from_url_string();
@@ -61,9 +61,15 @@ function render_callback( array $attributes ) : string {
 		$language_name    = $language_handler->get_language_names( array( $language_code ), 'english_name' )[ $language_code ];
 
 		$sort = array(
-		    array( 'field' => $language_name . ' Display Ranking', 'direction' => 'desc' ),
-		    array( 'field' => 'Display First', 'direction' => 'desc' )
-		    );
+			array(
+				'field' => $language_name . ' Display Ranking',
+				'direction' => 'desc',
+			),
+			array(
+				'field' => 'Display First',
+				'direction' => 'desc',
+			),
+		);
 		$resources_query->sort( $sort );
 	} else {
 		$resources_query->sort( 'Display First', 'desc' );

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -58,7 +58,7 @@ function render_callback( array $attributes ) : string {
 	if ($language_code) {
 		$language_handler = $trp->get_component('languages');
 		$language_name = $language_handler->get_language_names(array($language_code), 'english_name')[$language_code];
-		$resources_query->view("Language ".$language_name." site view");
+		$resources_query->view("Published (".$language_name.") Resources grouped by Resource Type - site embed view");
 	} else {
 		$resources_query->sort( 'Display First', 'desc' );
 	}
@@ -83,7 +83,7 @@ function render_callback( array $attributes ) : string {
 		if ($language_code) {
 			$need_name = $need[$language_name.' Translation'];
 		} else {
-		       $need_name = $need['Need'];
+			$need_name = $need['Need'];
 		}
 		$anchor = preg_replace( '/[^a-z0-9]+/', '+', strtolower($need_name));
 		$anchor = trim( $anchor, '+' );

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -51,14 +51,20 @@ function render_callback( array $attributes ) : string {
 	$resources_query = new AirpressQuery( 'Resources', 0 );
 	$resources_query->addFilter( '{Publish Status of Resource} = "Published"' );
 
-	$trp           = TRP_Translate_Press::get_trp_instance();
-	$url_converter = $trp->get_component( 'url_converter' );
-	$language_code = $url_converter->get_lang_from_url_string();
-
+	if (class_exists('TRP_TRANSLATE_PRESS')) {
+		$trp           = TRP_Translate_Press::get_trp_instance();
+		$url_converter = $trp->get_component( 'url_converter' );
+		$language_code = $url_converter->get_lang_from_url_string();
+	}
 	if ( $language_code ) {
 		$language_handler = $trp->get_component( 'languages' );
 		$language_name    = $language_handler->get_language_names( array( $language_code ), 'english_name' )[ $language_code ];
-		$resources_query->view( 'Published (' . $language_name . ') Resources grouped by Resource Type - site embed view' );
+
+		$sort = array(
+		    array( 'field' => $language_name . ' Display Ranking', 'direction' => 'desc' ),
+		    array( 'field' => 'Display First', 'direction' => 'desc' )
+		    );
+		$resources_query->sort( $sort );
 	} else {
 		$resources_query->sort( 'Display First', 'desc' );
 	}

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -11,6 +11,7 @@ use const MutualAidNYC\Blocks\ADD_BLOCK_HOOK;
 use AirpressQuery;
 use AirpressCollection;
 use WPCom_GHF_Markdown_Parser;
+use TRP_Translate_Press;
 
 add_action( ADD_BLOCK_HOOK, __NAMESPACE__ . '\\block_init' );
 
@@ -49,8 +50,18 @@ function render_callback( array $attributes ) : string {
 
 	$resources_query = new AirpressQuery( 'Resources', 0 );
 	$resources_query->addFilter( '{Publish Status of Resource} = "Published"' );
-	$resources_query->sort( 'Display First', 'desc' );
 
+	$trp = TRP_Translate_Press::get_trp_instance();
+	$url_converter = $trp->get_component( 'url_converter' );
+	$language_code = $url_converter->get_lang_from_url_string();
+
+	if ($language_code) {
+		$language_handler = $trp->get_component('languages');
+		$language_name = $language_handler->get_language_names(array($language_code), 'english_name')[$language_code];
+		$resources_query->view("Language ".$language_name." site view");
+	} else {
+		$resources_query->sort( 'Display First', 'desc' );
+	}
 	$needs = new AirpressCollection( $needs_query );
 	$needs->populateRelatedField( 'Resources', $resources_query );
 
@@ -69,13 +80,18 @@ function render_callback( array $attributes ) : string {
 		if ( count( $need['Resources'] ) === 0 ) {
 			continue;
 		}
-		$anchor = preg_replace( '/[^a-z0-9]+/', '+', strtolower( $need['Need'] ) );
+		if ($language_code) {
+			$need_name = $need[$language_name.' Translation'];
+		} else {
+		       $need_name = $need['Need'];
+		}
+		$anchor = preg_replace( '/[^a-z0-9]+/', '+', strtolower($need_name));
 		$anchor = trim( $anchor, '+' );
 		$html  .= '<details class="resources__need">';
 		$html  .= sprintf(
 			'<summary class="resources__need-title" id="%1$s">%2$s</summary>',
 			esc_attr( $anchor ),
-			esc_html( $need['Need'] )
+			esc_html( $need_name )
 		);
 		$html  .= '<div class="resources__item-wrapper">';
 		foreach ( $need['Resources'] as $resource ) {

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -49,6 +49,7 @@ function render_callback( array $attributes ) : string {
 
 	$resources_query = new AirpressQuery( 'Resources', 0 );
 	$resources_query->addFilter( '{Publish Status of Resource} = "Published"' );
+	$resources_query->sort( 'Display First', 'desc' );
 
 	$needs = new AirpressCollection( $needs_query );
 	$needs->populateRelatedField( 'Resources', $resources_query );


### PR DESCRIPTION
I assume you still have a staging environment similar to prod. Can you test this there?

Go to Resources page. The long English list (Childcare, Delivery/Transport, etc) should be there. Clicking “Childcare” should display “Workers Need Childcare”.

Switch to Spanish via language switcher in lower right corner of page. Now you should see a much shorter list of Spanish options - "Biblioteca de recursos adicionales", "Internet y tecnologia", and "Salud mental". Clicking "Salud Mental" and should expand to "24/7 Linea Directa Sobre Salud Mental y Abuso de Sustancias"