### PR TITLE
Resources styles

### DIFF
--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -135,7 +135,7 @@ function render_callback( array $attributes ) : string {
 				}
 
 				$html .= sprintf(
-					'<p class="resources__item-group">Provided by %s</p>',
+					'<p class="resources__item-group">' . esc_html__( 'Provided by %s' ) . '</p>',
 					implode( ', ', $group_names )
 				);
 			}

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -135,7 +135,7 @@ function render_callback( array $attributes ) : string {
 				}
 
 				$html .= sprintf(
-					'<p class="resources__item-group">' . esc_html__( 'Provided by %s' ) . '</p>',
+					'<p class="resources__item-group">' . esc_html__( 'Provided by %s', 'mutualaidnyc' ) . '</p>',
 					implode( ', ', $group_names )
 				);
 			}

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -75,7 +75,7 @@ function render_callback( array $attributes ) : string {
 	} else {
 		$resources_query->sort( 'Display First', 'desc' );
 	}
-	
+
 	$groups_query = new AirpressQuery( 'Groups', 0 );
 	$groups_query->addFilter( 'NOT({Group Name} = "-No Associated Group" )' );
 
@@ -99,7 +99,7 @@ function render_callback( array $attributes ) : string {
 		if ( count( $need['Resources'] ) === 0 ) {
 			continue;
 		}
-		if ( $language_code ) {
+		if ( isset( $language_code ) ) {
 			$need_name = $need[ $language_name . ' Translation' ];
 		} else {
 			$need_name = $need['Need'];

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -135,8 +135,9 @@ function render_callback( array $attributes ) : string {
 				}
 
 				$html .= sprintf(
+					// translators: %s is a comma separated list of group names.
 					'<p class="resources__item-group">' . esc_html__( 'Provided by %s', 'mutualaidnyc' ) . '</p>',
-					implode( ', ', $group_names )
+					implode( _x( ', ', 'Separator between group names.', 'mutualaidnyc' ), $group_names )
 				);
 			}
 

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -75,8 +75,14 @@ function render_callback( array $attributes ) : string {
 	} else {
 		$resources_query->sort( 'Display First', 'desc' );
 	}
+	
+	$groups_query = new AirpressQuery( 'Groups', 0 );
+	$groups_query->addFilter( 'NOT({Group Name} = "-No Associated Group" )' );
+
 	$needs = new AirpressCollection( $needs_query );
 	$needs->populateRelatedField( 'Resources', $resources_query );
+
+	$needs->populateRelatedField( 'Resources|Group', $groups_query);
 
 	$html = sprintf(
 		'<div class="wp-block-resources %s">',
@@ -106,23 +112,45 @@ function render_callback( array $attributes ) : string {
 			esc_attr( $anchor ),
 			esc_html( $need_name )
 		);
-		$html  .= '<div class="resources__item-wrapper">';
-		foreach ( $need['Resources'] as $resource ) {
+		$html  .= '<ul class="resources__item-wrapper">';
+
+		foreach ( $need['Resources'] as $resource ) { 
+			$html .=  '<li class="resources__item">';
+
 			$html .= sprintf(
-				'<div class="resources__item">
-					<span class="resources__tag resources__tag--%5$s">%4$s</span>
-					<h3 class="resources__item-title">%1$s</h3>
-					%2$s
-					<p><a href="%3$s" class="resources__item-link">%3$s</a></p>
-				</div>',
-				esc_html( $resource['Resource Title'] ),
-				wp_kses_post( markdown_to_html( $resource['Resource Details'], $markdown_parser ) ),
+				'<h3 class="resources__item-title"><a href="%s">%s</a></h3>',
 				esc_url( $resource['Link to Resource'] ?? '' ),
-				esc_html( $resource['Resource Type'] ?? '' ),
-				esc_attr( strtolower( $resource['Resource Type'] ?? '' ) )
+				esc_html( $resource['Resource Title'] ),
 			);
+			
+			if (sizeof($resource['Group'])) {
+				$group_names = [];
+
+				foreach ($resource['Group'] as $group) {
+					if (isset($group['Website'])) {
+						array_push($group_names, sprintf('<a href="%s">%s</a>', esc_url($group['Website']), esc_html($group['Group Name'])));
+					} else {
+						array_push($group_names, $group['Group Name']);
+					}
+				}
+
+				$html .= sprintf(
+					'<p class="resources__item-group">Provided by %s</p>',
+					implode(', ', $group_names)
+				);
+			}
+
+			$html .= sprintf(
+				'<span class="resources__tag resources__tag--%s">%s</span>',
+				esc_attr( strtolower( $resource['Resource Type'] ?? '' ) ),
+				esc_html( $resource['Resource Type'] ?? '' ),
+			);
+
+			$html .= wp_kses_post( markdown_to_html( $resource['Resource Details'], $markdown_parser ) );
+
+			$html .= '<hr /></li>';
 		}
-		$html .= '</div>';
+		$html .= '</ul>';
 		$html .= '</details>';
 	}
 	$html .= '</div>';
@@ -135,7 +163,7 @@ function render_callback( array $attributes ) : string {
  *
  * @param string                    $markdown The markdown from the API.
  * @param WPCom_GHF_Markdown_Parser $parser   The parser to use.
- * @return string
+ * @return string	
  */
 function markdown_to_html( string $markdown, $parser = null ) : string {
 	$html = '';

--- a/blocks/resources/block.php
+++ b/blocks/resources/block.php
@@ -82,7 +82,7 @@ function render_callback( array $attributes ) : string {
 	$needs = new AirpressCollection( $needs_query );
 	$needs->populateRelatedField( 'Resources', $resources_query );
 
-	$needs->populateRelatedField( 'Resources|Group', $groups_query);
+	$needs->populateRelatedField( 'Resources|Group', $groups_query );
 
 	$html = sprintf(
 		'<div class="wp-block-resources %s">',
@@ -114,29 +114,29 @@ function render_callback( array $attributes ) : string {
 		);
 		$html  .= '<ul class="resources__item-wrapper">';
 
-		foreach ( $need['Resources'] as $resource ) { 
-			$html .=  '<li class="resources__item">';
+		foreach ( $need['Resources'] as $resource ) {
+			$html .= '<li class="resources__item">';
 
 			$html .= sprintf(
 				'<h3 class="resources__item-title"><a href="%s">%s</a></h3>',
 				esc_url( $resource['Link to Resource'] ?? '' ),
 				esc_html( $resource['Resource Title'] ),
 			);
-			
-			if (sizeof($resource['Group'])) {
+
+			if ( count( $resource['Group'] ) ) {
 				$group_names = [];
 
-				foreach ($resource['Group'] as $group) {
-					if (isset($group['Website'])) {
-						array_push($group_names, sprintf('<a href="%s">%s</a>', esc_url($group['Website']), esc_html($group['Group Name'])));
+				foreach ( $resource['Group'] as $group ) {
+					if ( isset( $group['Website'] ) ) {
+						array_push( $group_names, sprintf( '<a href="%s">%s</a>', esc_url( $group['Website'] ), esc_html( $group['Group Name'] ) ) );
 					} else {
-						array_push($group_names, $group['Group Name']);
+						array_push( $group_names, $group['Group Name'] );
 					}
 				}
 
 				$html .= sprintf(
 					'<p class="resources__item-group">Provided by %s</p>',
-					implode(', ', $group_names)
+					implode( ', ', $group_names )
 				);
 			}
 
@@ -163,7 +163,7 @@ function render_callback( array $attributes ) : string {
  *
  * @param string                    $markdown The markdown from the API.
  * @param WPCom_GHF_Markdown_Parser $parser   The parser to use.
- * @return string	
+ * @return string
  */
 function markdown_to_html( string $markdown, $parser = null ) : string {
 	$html = '';

--- a/blocks/resources/style.css
+++ b/blocks/resources/style.css
@@ -35,8 +35,12 @@
 .resources__need[open] > summary::after {
 	content: '\f142';
 }
+.resources__item-wrapper {
+	margin: 0;
+}
 .resources__item {
 	margin: 4rem 10px;
+	list-style: none;
 }
 .resources__item > *:not( .resources__tag ) {
 	user-select: text;
@@ -49,6 +53,7 @@
 	padding: 0.5rem 1rem;
 	background-color: var( --color-primary-text );
 	text-transform: uppercase;
+	margin-bottom: 2rem;
 }
 .resources__tag--service {
 	background-color: var( --color-tertiary-text );
@@ -63,12 +68,21 @@
 .resources__tag--course {
 	background-color: var( --color-accent-text );
 }
+
 .entry-content h3.resources__item-title {
+	margin: 0 0 2rem;
+}
+
+.entry-content h3.resources__item-title a {
+	text-decoration: underline !important;
 	font-size: 1.2em;
 	font-family: var( --font-body );
 	color: black;
 	line-height: 1.476;
-	font-weight: bold;
 	letter-spacing: normal;
-	margin: 1rem 0;
+}
+
+.resources__item-group {
+	color: var( --color-accent-text );
+	margin-bottom: 2rem;
 }


### PR DESCRIPTION
- Added a list of groups to each resource (if there is/are associated groups).

- Updated design to match mock in https://www.notion.so/manyc/fd4cef9fca0345d19f28eb2b96d57d7b?v=4628ac68c4204fa3ae79dd5a4798c830&p=c454850bd538456e8ef5652e4ad2e30c

- Updated `resources__item-wrapper` to be a `<ul>` with each `resources__item` as an `<li>`. It's more semantic so should be better for accessibility.

- Added `isset()` check around `$langauge_code` on line 102. It was causing an error and I think this just got missed in the previous translation PR.

**OLD:**
<img src="https://user-images.githubusercontent.com/961994/88976527-35505b80-d28a-11ea-9ee0-047821278621.png" width=600px />

**NEW:**
<img src="https://user-images.githubusercontent.com/961994/88976571-46996800-d28a-11ea-9f8c-3c1b97ae2cf4.png" width=600px />
